### PR TITLE
Change grid_map to octomap_grid

### DIFF
--- a/roomac_move_base/launch/move_base.launch
+++ b/roomac_move_base/launch/move_base.launch
@@ -1,7 +1,7 @@
 <launch>
 
   <node pkg="move_base" type="move_base" name="move_base_node" output="screen" clear_params="true">
-    <remap from="map" to="rtabmap/grid_map"/>
+    <remap from="map" to="rtabmap/octomap_grid"/>
 
     <!-- dwa local planner-->
     <param name="base_local_planner" value="dwa_local_planner/DWAPlannerROS" />

--- a/roomac_move_base/launch/move_base_fusion.launch
+++ b/roomac_move_base/launch/move_base_fusion.launch
@@ -1,7 +1,7 @@
 <launch>
 
   <node pkg="move_base" type="move_base" name="move_base_node" output="screen" clear_params="true">
-    <remap from="map" to="rtabmap/grid_map"/>
+    <remap from="map" to="rtabmap/octomap_grid"/>
     <remap from="odom" to="odometry/filtered"/>
 
     <!-- dwa local planner-->

--- a/roomac_move_base/rviz/rviz_move_base.rviz
+++ b/roomac_move_base/rviz/rviz_move_base.rviz
@@ -58,7 +58,7 @@ Visualization Manager:
       Draw Behind: false
       Enabled: true
       Name: Map
-      Topic: /rtabmap/grid_map
+      Topic: /rtabmap/octomap_grid
       Unreliable: false
       Use Timestamp: false
       Value: true

--- a/roomac_rtabmap/rviz/roomac_rtabmap.rviz
+++ b/roomac_rtabmap/rviz/roomac_rtabmap.rviz
@@ -86,7 +86,7 @@ Visualization Manager:
       Draw Behind: false
       Enabled: true
       Name: Map
-      Topic: /rtabmap/grid_map
+      Topic: /rtabmap/octomap_grid
       Unreliable: false
       Use Timestamp: false
       Value: true

--- a/roomac_rtabmap/rviz/roomac_rtabmap_mapping.rviz
+++ b/roomac_rtabmap/rviz/roomac_rtabmap_mapping.rviz
@@ -86,7 +86,7 @@ Visualization Manager:
       Draw Behind: false
       Enabled: true
       Name: Map
-      Topic: /rtabmap/grid_map
+      Topic: /rtabmap/octomap_grid
       Unreliable: false
       Use Timestamp: false
       Value: true

--- a/roomac_simulation/rviz/simulation_rtabmap.rviz
+++ b/roomac_simulation/rviz/simulation_rtabmap.rviz
@@ -147,7 +147,7 @@ Visualization Manager:
       Draw Behind: false
       Enabled: true
       Name: Map
-      Topic: /rtabmap/grid_map
+      Topic: /rtabmap/octomap_grid
       Unreliable: false
       Use Timestamp: false
       Value: true


### PR DESCRIPTION
Closes #14 
bump::patch

Fix grid_map not updating - change grid_map to octomap_grid. Not exactly the same, but octomap_grid is at least correctly updated.